### PR TITLE
Allow passing in no arguments.

### DIFF
--- a/nukeeper/task.json
+++ b/nukeeper/task.json
@@ -44,7 +44,7 @@
           "type": "string",
           "label": "Arguments",
           "defaultValue": "-m 3",
-          "required": true,
+          "required": false,
           "helpMarkDown": "Append extra configuration options"
         },
         {


### PR DESCRIPTION
See title.

The `Arguments` fields shouldn't be required since NuKeeper can run perfectly fine without it.